### PR TITLE
Update to babel 7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,9 @@
 {
-  "presets": [
-    [ "es2015", { "loose": true } ]
-  ],
-  "plugins": [
-    "transform-runtime"
-  ]
+  "presets": [["@babel/preset-env", {
+    "targets": {
+      "node": "6"
+    },
+    "loose": true
+  }]],
+  "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -15,16 +15,20 @@
     "type": "git",
     "url": "https://github.com/pugjs/babylon-walk.git"
   },
+  "engines": {
+    "node": ">= 6.0.0"
+  },
   "author": "Timothy Gu <timothygu99@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "^6.11.6",
-    "babel-types": "^6.15.0",
+    "@babel/runtime": "^7.0.0",
+    "@babel/types": "^7.0.0",
     "lodash.clone": "^4.5.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.14.0",
-    "babel-plugin-transform-runtime": "^6.15.0",
-    "babel-preset-es2015": "^6.14.0"
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.0.0",
+    "@babel/preset-env": "^7.0.0"
   }
 }

--- a/src/explode.js
+++ b/src/explode.js
@@ -2,7 +2,7 @@
 // https://github.com/babel/babel/blob/07b3dc18a09f2217b38a3a63c8613add6df1b47d/packages/babel-traverse/src/visitors.js
 
 // import * as messages from 'babel-messages';
-import * as t from "babel-types";
+import * as t from "@babel/types";
 import clone from "lodash.clone";
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import * as t from 'babel-types';
+import * as t from '@babel/types';
 import explode from './explode.js';
 
 export function simple(node, visitors, state) {


### PR DESCRIPTION
There has been some changes in the typings package. So I updated that package to v7.
While I was at it, I also added an engines field in package.json and updated the internally used babel to 7 so builds go slightly faster and benefit from all new bugfixes.

This is a breaking change, as support for Babel 6 will be dropped.